### PR TITLE
Companion plugin bootstrap parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,73 @@
 # GatherPress Awesome
 
-*GatherPress Awesome* is a starter plugin, an example of how to structure and organize a companion plugin for GatherPress. It uses the entry points provided by GatherPress to show how and where one could hook into the code and its underlying processes.
+A starter plugin for building **companion plugins** that extend [GatherPress](https://github.com/GatherPress/gatherpress) — the WordPress plugin for community event management.
 
-## Already prepared for your GatherPress Awesome plugin
+It's not meant to ship as-is. Clone it, rename it, and use it as a working scaffold for your own GatherPress add-on.
 
-- [x] Registers your Awesome namespace and adds it to GatherPress' autoloader
-- [x] Adds an Awesome settings tab to the GatherPress settings
+## What you get out of the box
+
+- Plugin bootstrap that **registers the dependency on GatherPress** (`Requires Plugins: gatherpress`) so WordPress 6.5+ surfaces it on the Plugins screen and won't activate the companion without it.
+- An **admin notice** if GatherPress isn't loaded for any reason, so the failure mode is visible instead of silent.
+- A **duplicate-folder guard** that bails when a sibling copy is already loaded (for example, if WordPress includes `gatherpress-awesome-2/` alongside `gatherpress-awesome/`).
+- Registration with GatherPress's **coexistence guard**, so two folders of the same companion plugin can't both activate.
+- Your namespace **wired into GatherPress's class autoloader**, so dropping `includes/classes/class-foo.php` is enough to load `GatherPress_Awesome\Foo`.
+- An **"Awesome" settings sub-page** rendered inside *Settings → GatherPress* — the simplest example of hooking into GatherPress's UI.
 
     <details><summary>Preview</summary>
 
     ![A new "Awesome" settings tab in the GatherPress settings](https://github.com/user-attachments/assets/585e4cdb-cdde-4373-b999-b35aaca06c5e)
 
-    </details> 
+    </details>
 
-- [x] Test [GatherPress Awesome in Playground](https://playground.wordpress.net/builder/builder.html?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress-awesome/main/.wordpress-org/blueprints/blueprint.json), with GatherPress installed & [gatherpress-demo-data](https://github.com/GatherPress/gatherpress-demo-data) already in place.
+- A ready-to-go **[Playground blueprint](https://playground.wordpress.net/builder/builder.html?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress-awesome/main/.wordpress-org/blueprints/blueprint.json)** that boots WordPress with both GatherPress and this companion installed, plus [gatherpress-demo-data](https://github.com/GatherPress/gatherpress-demo-data) already in place.
 
     <details><summary>Preview</summary>
 
     ![GatherPress & GatherPress Awesome pre-installed and activated in WordPress Playground](https://github.com/user-attachments/assets/011742dc-2fa9-4b7b-b10f-8023cc7b77af)
 
-    </details> 
+    </details>
+
+- An `uninstall.php` scaffold that walks the multisite blog list and deletes a placeholder option — swap in your own option names when you start storing data.
+
+## File layout
+
+```
+gatherpress-awesome/
+├── gatherpress-awesome.php        # Plugin bootstrap (header, autoloader, boot guard, coexistence guard)
+├── uninstall.php                  # Multisite-aware option cleanup on uninstall
+├── includes/classes/
+│   └── class-setup.php            # Singleton entry point — register your hooks here
+├── .wordpress-org/blueprints/
+│   └── blueprint.json             # Playground boot recipe
+└── package.json                   # @wordpress/scripts (build, lint, format, plugin-zip)
+```
+
+## Quick start
+
+1. **Clone** the repository into your local `wp-content/plugins/` directory and rename the folder to whatever you want (e.g., `gatherpress-myplugin`).
+2. **Find-and-replace** these tokens across every file (case-sensitive):
+   - `gatherpress-awesome` → `gatherpress-myplugin`
+   - `gatherpress_awesome` → `gatherpress_myplugin`
+   - `GATHERPRESS_AWESOME` → `GATHERPRESS_MYPLUGIN`
+   - `GatherPress_Awesome` → `GatherPress_Myplugin`
+   - `GatherPress Awesome` → `GatherPress Myplugin`
+3. **Rename the entry file**: `gatherpress-awesome.php` → `gatherpress-myplugin.php`. The filename, the folder name, and the slug passed to `gatherpress_register_coexistence_guard()` must all match.
+4. **Update `package.json`** (name, description, repository) and bump the plugin header `Version`.
+5. **Activate** GatherPress + your renamed companion in WordPress.
+
+## Where to extend
+
+Most of your work happens inside `GatherPress_Awesome\Setup::setup_hooks()` (or new sibling classes you autoload via the same namespace). Common extension points GatherPress exposes:
+
+- **Hooks** — see [`docs/developer/hooks/`](https://github.com/GatherPress/gatherpress/tree/develop/docs/developer/hooks) in the GatherPress repo for the full filter and action catalog (auto-generated on every release).
+- **Block patterns** — register your own starter patterns via `gatherpress_event_starter_patterns` and `gatherpress_venue_starter_patterns` filters; see the [pattern picker docs](https://github.com/GatherPress/gatherpress/tree/develop/docs/developer/blocks).
+- **Settings sub-pages** — the `gatherpress_sub_pages` filter is what wires the Awesome tab demo. Add fields to your sub-page using GatherPress's settings API.
+- **Block hooks** — extend the canonical event/venue layouts via the `hooked_block_types` WordPress core API; see the [hookable patterns docs](https://github.com/GatherPress/gatherpress/tree/develop/docs/developer/blocks/hookable-patterns).
 
 ## Up to you
 
-- [ ] [Create your own GatherPress Awesome demo-data](https://github.com/carstingaxion/crud-the-docs-playground), and add it to your [`blueprint.json`](/.wordpress-org/blueprints/blueprint.json).
+- [ ] [Create your own demo-data plugin](https://github.com/carstingaxion/crud-the-docs-playground) and reference it from your `.wordpress-org/blueprints/blueprint.json` so reviewers can spin up a representative sandbox in one click.
+
+## License
+
+GPLv2 or later. See `LICENSE` in this repository.

--- a/gatherpress-awesome.php
+++ b/gatherpress-awesome.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Plugin Name:  GatherPress Awesome
- * Plugin URI:   https://gatherpress.org/
- * Description:  Powering Communities with WordPress.
- * Author:       The GatherPress Community
- * Author URI:   https://gatherpress.org/
- * Version:      1.0.0
- * Requires PHP: 7.4
- * Text Domain:  gatherpress-awesome
- * Domain Path:  /languages
- * License:      GNU General Public License v2.0 or later
- * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
- *
+ * Plugin Name:      GatherPress Awesome
+ * Plugin URI:       https://gatherpress.org/
+ * Description:      Powering Communities with WordPress.
+ * Author:           The GatherPress Community
+ * Author URI:       https://gatherpress.org/
+ * Version:          1.0.0
+ * Requires PHP:     7.4
+ * Requires Plugins: gatherpress
+ * Text Domain:      gatherpress-awesome
+ * Domain Path:      /languages
+ * License:          GNU General Public License v2.0 or later
+ * License URI:      https://www.gnu.org/licenses/gpl-2.0.html
  *
  * @package GatherPress_Awesome
  */
@@ -19,7 +19,12 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-// Constants.
+// Bail when a sibling copy is already loaded (e.g., when WordPress includes a
+// duplicate folder during activation).
+if ( defined( 'GATHERPRESS_AWESOME_VERSION' ) ) {
+	return;
+}
+
 define( 'GATHERPRESS_AWESOME_VERSION', current( get_file_data( __FILE__, array( 'Version' ), 'plugin' ) ) );
 define( 'GATHERPRESS_AWESOME_CORE_PATH', __DIR__ );
 
@@ -42,16 +47,44 @@ add_filter( 'gatherpress_autoloader', 'gatherpress_awesome_autoloader' );
 /**
  * Initializes the GatherPress Awesome setup.
  *
- * This function hooks into the 'plugins_loaded' action to ensure that
- * the GatherPress_Awesome\Setup instance is created once all plugins are loaded,
- * only if the GatherPress plugin is active.
+ * Boots the runtime once all plugins have loaded, but only when GatherPress
+ * itself is present. Surfaces an admin notice when it isn't, so the failure
+ * mode is visible instead of silent.
  *
  * @return void
  */
 function gatherpress_awesome_setup(): void {
-	if ( defined( 'GATHERPRESS_VERSION' ) ) {
-		GatherPress_Awesome\Setup::get_instance();
+	if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
+		add_action(
+			'admin_notices',
+			static function (): void {
+				?>
+				<div class="notice notice-error">
+					<p><?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-awesome' ); ?></p>
+				</div>
+				<?php
+			}
+		);
+
+		return;
 	}
 
+	GatherPress_Awesome\Setup::get_instance();
 }
 add_action( 'plugins_loaded', 'gatherpress_awesome_setup' );
+
+/**
+ * Announce this plugin to GatherPress's coexistence guard.
+ *
+ * Fired on `plugins_loaded` so the registration runs after every active
+ * plugin has loaded — GatherPress's listener is then guaranteed to be in
+ * place regardless of plugin order in the `active_plugins` option. When
+ * GatherPress is not active, the action fires into the void — no fatal,
+ * no side effect.
+ *
+ * @return void
+ */
+function gatherpress_awesome_register_coexistence_guard(): void {
+	do_action( 'gatherpress_register_coexistence_guard', 'gatherpress-awesome', 'GatherPress Awesome', __FILE__ );
+}
+add_action( 'plugins_loaded', 'gatherpress_awesome_register_coexistence_guard' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Uninstall GatherPress Awesome.
+ *
+ * Removes all plugin data from the database when the plugin is uninstalled.
+ * Replace the placeholder option name(s) below with whatever your companion
+ * plugin actually persists, or remove this file if you never write options.
+ *
+ * @package GatherPress_Awesome
+ */
+
+// Exit if accessed directly or not called from WordPress.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+/**
+ * Delete plugin options.
+ */
+delete_option( 'gatherpress_awesome_example' );
+
+/**
+ * For multisite installations, delete the option from all sites.
+ */
+if ( is_multisite() ) {
+	global $wpdb;
+
+	$blog_ids = $wpdb->get_col( "SELECT blog_id FROM {$wpdb->blogs}" );
+
+	foreach ( $blog_ids as $blog_id ) {
+		switch_to_blog( $blog_id );
+		delete_option( 'gatherpress_awesome_example' );
+		restore_current_blog();
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,9 +2,27 @@
 /**
  * Uninstall GatherPress Awesome.
  *
- * Removes all plugin data from the database when the plugin is uninstalled.
- * Replace the placeholder option name(s) below with whatever your companion
- * plugin actually persists, or remove this file if you never write options.
+ * WordPress runs this file when a user deletes the plugin from the Plugins
+ * screen — not on deactivation, only on full uninstall. This is where any
+ * data your companion plugin persisted should be cleaned up so deleting the
+ * plugin truly removes its footprint from the database.
+ *
+ * Common things to delete here:
+ *
+ *   - `delete_option( 'your_option_key' );`
+ *   - `delete_site_option( 'your_network_option_key' );` (multisite)
+ *   - Custom post type entries via `wp_delete_post()` (use sparingly — many
+ *     authors leave content alone on uninstall)
+ *   - Custom tables via `$wpdb->query( "DROP TABLE …" )`
+ *   - Scheduled cron events via `wp_clear_scheduled_hook()`
+ *   - User meta via `delete_metadata( 'user', 0, 'your_meta_key', '', true )`
+ *
+ * On multisite, loop over every site with `get_sites()` /
+ * `switch_to_blog()` / `restore_current_blog()` so per-site options get
+ * cleaned across the network.
+ *
+ * The bare-minimum guard below ensures this file only ever runs from
+ * WordPress's uninstall flow — never from a direct request.
  *
  * @package GatherPress_Awesome
  */
@@ -14,22 +32,4 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-/**
- * Delete plugin options.
- */
-delete_option( 'gatherpress_awesome_example' );
-
-/**
- * For multisite installations, delete the option from all sites.
- */
-if ( is_multisite() ) {
-	global $wpdb;
-
-	$blog_ids = $wpdb->get_col( "SELECT blog_id FROM {$wpdb->blogs}" );
-
-	foreach ( $blog_ids as $blog_id ) {
-		switch_to_blog( $blog_id );
-		delete_option( 'gatherpress_awesome_example' );
-		restore_current_blog();
-	}
-}
+// Add your cleanup here.


### PR DESCRIPTION
### Description of the Change

Brings GatherPress Awesome's bootstrap up to the same baseline as GatherPress Alpha so it's a stronger starting point for companion-plugin authors:

- **`Requires Plugins: gatherpress` header** — WP 6.5+ surfaces the dependency on the Plugins screen and blocks activation until GatherPress is installed.
- **Duplicate-folder guard** — early return if `GATHERPRESS_AWESOME_VERSION` is already defined, so a sibling copy can't double-load.
- **Admin notice when GatherPress isn't loaded** — replaces the silent no-op so the failure mode is visible.
- **`gatherpress_register_coexistence_guard` registration** — announces the plugin to GatherPress's coexistence guard so two folders of the same companion can't both activate.
- **`uninstall.php` scaffold** — placeholder option cleanup with the multisite-aware loop, ready for companion authors to swap in their actual option names.

### How to test the Change

1. Activate GatherPress Awesome on a site without GatherPress — admin notice appears, no fatals.
2. Install GatherPress, activate both — Awesome boots, sub-page renders.
3. Drop a copy of the folder as `gatherpress-awesome-test/` and try to activate — coexistence guard refuses.
4. Verify `Requires Plugins: gatherpress` shows on the Plugins screen.

### Changelog Entry

> Added - Bootstrap parity with GatherPress Alpha (`Requires Plugins` header, duplicate-folder guard, missing-GatherPress admin notice, coexistence guard registration, `uninstall.php` scaffold).

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.