### PR TITLE
Boot from gatherpress_loaded rather than the version constant (#9)

### DIFF
--- a/gatherpress-awesome.php
+++ b/gatherpress-awesome.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * Plugin Name:      GatherPress Awesome
- * Plugin URI:       https://gatherpress.org/
- * Description:      Powering Communities with WordPress.
- * Author:           The GatherPress Community
- * Author URI:       https://gatherpress.org/
- * Version:          1.0.0
- * Requires PHP:     7.4
- * Requires Plugins: gatherpress
- * Text Domain:      gatherpress-awesome
- * Domain Path:      /languages
- * License:          GNU General Public License v2.0 or later
- * License URI:      https://www.gnu.org/licenses/gpl-2.0.html
+ * Plugin Name:       GatherPress Awesome
+ * Plugin URI:        https://gatherpress.org/
+ * Description:       Powering Communities with WordPress.
+ * Author:            The GatherPress Community
+ * Author URI:        https://gatherpress.org/
+ * Version:           1.0.0
+ * Requires PHP:      7.4
+ * Requires at least: 6.7
+ * Requires Plugins:  gatherpress
+ * Text Domain:       gatherpress-awesome
+ * Domain Path:       /languages
+ * License:           GNU General Public License v2.0 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  *
  * @package GatherPress_Awesome
  */
@@ -45,46 +46,63 @@ function gatherpress_awesome_autoloader( array $namespace ): array {
 add_filter( 'gatherpress_autoloader', 'gatherpress_awesome_autoloader' );
 
 /**
- * Initializes the GatherPress Awesome setup.
+ * Boots the GatherPress Awesome runtime.
  *
- * Boots the runtime once all plugins have loaded, but only when GatherPress
- * itself is present. Surfaces an admin notice when it isn't, so the failure
- * mode is visible instead of silent.
+ * Hooked on `gatherpress_loaded`, which GatherPress fires only after its own
+ * requirements check passes. That is deliberate: the GATHERPRESS_* constants
+ * are defined *before* that check, so `defined( 'GATHERPRESS_VERSION' )` means
+ * "GatherPress began loading", not "GatherPress loaded successfully". Booting on
+ * the constant called into classes whose autoloader was never registered when
+ * GatherPress bailed, fataling the whole site (issue #9).
+ *
+ * Registered at file-load time rather than inside a `plugins_loaded` callback:
+ * GatherPress fires `gatherpress_loaded` from within its own `plugins_loaded`
+ * callback, which is registered first, so a listener added inside ours would be
+ * added after the action had already fired.
  *
  * @return void
  */
 function gatherpress_awesome_setup(): void {
-	if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
-		add_action(
-			'admin_notices',
-			static function (): void {
-				?>
-				<div class="notice notice-error">
-					<p><?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-awesome' ); ?></p>
-				</div>
-				<?php
-			}
-		);
+	GatherPress_Awesome\Setup::get_instance();
+}
+add_action( 'gatherpress_loaded', 'gatherpress_awesome_setup' );
 
+/**
+ * Surfaces why GatherPress Awesome is inert when GatherPress is absent.
+ *
+ * Stays on `plugins_loaded` because it must run in exactly the case where
+ * `gatherpress_loaded` never fires.
+ *
+ * @return void
+ */
+function gatherpress_awesome_maybe_notify_missing_gatherpress(): void {
+	if ( defined( 'GATHERPRESS_VERSION' ) ) {
 		return;
 	}
 
-	GatherPress_Awesome\Setup::get_instance();
+	add_action(
+		'admin_notices',
+		static function (): void {
+			wp_admin_notice(
+				esc_html__( 'GatherPress is not installed.', 'gatherpress-awesome' ),
+				array( 'type' => 'error' )
+			);
+		}
+	);
 }
-add_action( 'plugins_loaded', 'gatherpress_awesome_setup' );
+add_action( 'plugins_loaded', 'gatherpress_awesome_maybe_notify_missing_gatherpress' );
 
 /**
  * Announce this plugin to GatherPress's coexistence guard.
  *
- * Fired on `plugins_loaded` so the registration runs after every active
- * plugin has loaded — GatherPress's listener is then guaranteed to be in
- * place regardless of plugin order in the `active_plugins` option. When
- * GatherPress is not active, the action fires into the void — no fatal,
- * no side effect.
+ * On `gatherpress_loaded` rather than `plugins_loaded`: the guard's listener is
+ * registered by GatherPress during its own bootstrap, so the action is only
+ * ever heard once GatherPress finished loading. Firing it on `plugins_loaded`
+ * meant shouting into the void whenever GatherPress was absent or had bailed.
  *
  * @return void
  */
 function gatherpress_awesome_register_coexistence_guard(): void {
 	do_action( 'gatherpress_register_coexistence_guard', 'gatherpress-awesome', 'GatherPress Awesome', __FILE__ );
 }
-add_action( 'plugins_loaded', 'gatherpress_awesome_register_coexistence_guard' );
+add_action( 'gatherpress_loaded', 'gatherpress_awesome_register_coexistence_guard' );


### PR DESCRIPTION
Fixes #9. Same root cause and fix as [GatherPress Alpha #54](https://github.com/GatherPress/gatherpress-alpha/pull/54); companion to core [GatherPress#1983](https://github.com/GatherPress/gatherpress/pull/1983).

## The bug

When GatherPress fails its own requirements check — the reporter used a missing build directory, but PHP below the minimum does it too — GatherPress is meant to show a notice and not load. With Awesome active, the whole site white-screens instead.

`GATHERPRESS_VERSION` is defined in `gatherpress.php` **before** the requirements gate. When the gate fails, the file returns and the autoloader never registers — but the constant is already set. Awesome gated on `defined( 'GATHERPRESS_VERSION' )`, concluded GatherPress was ready, and called `GatherPress_Awesome\Setup::get_instance()`. Awesome's classes autoload through *GatherPress's* autoloader, which doesn't exist, so the class isn't found and the site fatals — exactly as the issue describes.

The constant means *"GatherPress's main file began executing."* Awesome was reading it as *"GatherPress finished bootstrapping."*

## The fix

Boot from the `gatherpress_loaded` action, which GatherPress fires only *after* the gate passes. When GatherPress bails, the action never fires and Awesome never boots.

- **"GatherPress is not installed" notice stays on `plugins_loaded`** — it has to run in exactly the case where `gatherpress_loaded` never fires.
- **Coexistence guard registration moves to `gatherpress_loaded`** — its listener is registered by GatherPress during bootstrap, so firing the action on `plugins_loaded` was shouting into the void whenever GatherPress was absent or had bailed.

## One detail worth reviewer attention

The boot listener is registered at **file-load time, not inside a `plugins_loaded` callback**. GatherPress fires `gatherpress_loaded` from within its own `plugins_loaded` callback, which is registered first — so a listener added inside ours would be added *after* the action had already fired, and Awesome would silently never boot.

Awesome has no version lock (unlike Alpha), so there's no version re-check inside the boot listener.

## Dependency

`gatherpress_loaded` exists on GatherPress `develop` but is **absent from both `main` and the `0.34.0` tag**, so it ships in core 0.34.1 via GatherPress#1983. This PR does nothing until that lands.

## Testing

Reproduced with the issue's steps — removed the GatherPress build directory, loaded a page, confirmed the fatal. With this change plus the core 0.34.1 build, the site loads and shows GatherPress's own "run npm run build" notice instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)